### PR TITLE
arachne-pnr switched to nextpnr for basic Verilog examples

### DIFF
--- a/src/basic/verilog/dsp/Makefile
+++ b/src/basic/verilog/dsp/Makefile
@@ -1,13 +1,27 @@
 filename = top
 pcf_file = ../../../common/io.pcf
 
+ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
+${warning iCELink path: $(ICELINK_DIR)}
+
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:
-	icesprog $(filename).bin
+	@if [ -d '$(ICELINK_DIR)' ]; \
+        then \
+            cp $(filename).bin $(ICELINK_DIR); \
+        else \
+            echo "iCELink not found"; \
+            exit 1; \
+    fi
 
 clean:
 	rm -rf $(filename).blif $(filename).asc $(filename).bin

--- a/src/basic/verilog/hard_rgb/Makefile
+++ b/src/basic/verilog/hard_rgb/Makefile
@@ -1,7 +1,7 @@
 filename = hard_led
 pcf_file = ../../../common/io.pcf
 
-ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$9}')
+ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 

--- a/src/basic/verilog/leds/Makefile
+++ b/src/basic/verilog/leds/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:

--- a/src/basic/verilog/pmod_leds/Makefile
+++ b/src/basic/verilog/pmod_leds/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:

--- a/src/basic/verilog/pmod_switch/Makefile
+++ b/src/basic/verilog/pmod_switch/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:

--- a/src/basic/verilog/pwm/Makefile
+++ b/src/basic/verilog/pwm/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 #prog: #for sram

--- a/src/basic/verilog/spram/Makefile
+++ b/src/basic/verilog/spram/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:

--- a/src/basic/verilog/switch/Makefile
+++ b/src/basic/verilog/switch/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 prog_flash:

--- a/src/basic/verilog/uart_tx/Makefile
+++ b/src/basic/verilog/uart_tx/Makefile
@@ -5,8 +5,13 @@ ICELINK_DIR=$(shell df | grep iCELink | awk '{print $$6}')
 ${warning iCELink path: $(ICELINK_DIR)}
 
 build:
-	yosys -p "synth_ice40 -blif $(filename).blif" $(filename).v
-	arachne-pnr -d 5k -P sg48 -p $(pcf_file) $(filename).blif -o $(filename).asc
+	yosys -p "synth_ice40 -json $(filename).json" $(filename).v
+	nextpnr-ice40 \
+		--up5k \
+		--package sg48 \
+		--json $(filename).json \
+		--pcf $(pcf_file) \
+		--asc $(filename).asc
 	icepack $(filename).asc $(filename).bin
 
 #prog: #for sram


### PR DESCRIPTION
Updated Makefile's in basic Verilog examples to use `nextpnr` instead of `arachne-pnr`. Examples that used more advanced make configurations were left untouched as well as examples that had arachne or nextpnr options. 

The following examples were updated, tested for build, and programmed onto the ICESugar V1.5 board:

- dsp
- hard_rgb
- leds
- pmod_leds
- pmod_switch
- pwm
- spram
- switch
- uart_tx
